### PR TITLE
use setuptools & javascript strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
 build/
-*.pyc
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/flask_jsglue.py
+++ b/flask_jsglue.py
@@ -37,10 +37,12 @@ class JSGlue(object):
     def generate_js(self):
         rules = get_routes(self.app)
         return """
-var %s = new (function(){ return {
+var %s = new (function(){
+    'use strict';
+    return {
         '_endpoints': %s,
         'url_for': function(endpoint, rule) {
-            if(rule === undefined) rule = {};
+            if(typeof rule === "undefined") rule = {};
 
             var has_everything = false, url = "";
             
@@ -53,7 +55,7 @@ var %s = new (function(){ return {
                 delete rule['_external'];
             }
 
-            if(rule['_scheme'] !== undefined) {
+            if('_scheme' in rule) {
                 if(is_absolute) {
                     scheme = rule['_scheme'];
                     delete rule['_scheme'];
@@ -62,7 +64,7 @@ var %s = new (function(){ return {
                 }
             }
 
-            if(rule['_anchor'] !== undefined) {
+            if('_anchor' in rule) {
                 has_anchor = true;
                 anchor = rule['_anchor'];
                 delete rule['_anchor'];
@@ -70,10 +72,12 @@ var %s = new (function(){ return {
 
             for(var i in this._endpoints) {
                 if(endpoint == this._endpoints[i][0]) {
-                    url = ''; j = 0; has_everything = true;
+                    var url = '';
+                    var j = 0;
+                    var has_everything = true;
                     for(var j = 0; j < this._endpoints[i][2].length; j++) {
-                        t = rule[this._endpoints[i][2][j]];
-                        if(t == undefined) {
+                        var t = rule[this._endpoints[i][2][j]];
+                        if(typeof t === "undefined") {
                             has_everything = false;
                             break;
                         }
@@ -98,7 +102,8 @@ var %s = new (function(){ return {
 
             throw {name: 'BuildError', message: "Couldn't find the matching endpoint."};
         }
-};});""" % (JSGLUE_NAMESPACE, json.dumps(rules)) 
+    };
+});""" % (JSGLUE_NAMESPACE, json.dumps(rules)) 
 
     @staticmethod
     def include():

--- a/flask_jsglue.py
+++ b/flask_jsglue.py
@@ -1,7 +1,7 @@
 from flask import current_app, make_response
 from jinja2 import Markup
 import re, json
-   
+
 JSGLUE_JS_PATH = '/jsglue.js'
 JSGLUE_NAMESPACE = 'Flask'
 rule_parser = re.compile(r'<(.+?)>')
@@ -45,12 +45,12 @@ var %s = new (function(){
             if(typeof rule === "undefined") rule = {};
 
             var has_everything = false, url = "";
-            
+
             var is_absolute = false, has_anchor = false, has_scheme;
             var anchor = "", scheme = "";
 
             if(rule['_external'] === true) {
-                is_absolute = true; 
+                is_absolute = true;
                 scheme = location.protocol.split(':')[0];
                 delete rule['_external'];
             }
@@ -84,7 +84,7 @@ var %s = new (function(){
                         url += this._endpoints[i][1][j] + t;
                     }
                     if(has_everything) {
-                        if(this._endpoints[i][2].length != this._endpoints[i][1].length) 
+                        if(this._endpoints[i][2].length != this._endpoints[i][1].length)
                             url += this._endpoints[i][1][j];
 
                         if(has_anchor) {
@@ -98,12 +98,12 @@ var %s = new (function(){
                         }
                     }
                 }
-            }                
+            }
 
             throw {name: 'BuildError', message: "Couldn't find the matching endpoint."};
         }
     };
-});""" % (JSGLUE_NAMESPACE, json.dumps(rules)) 
+});""" % (JSGLUE_NAMESPACE, json.dumps(rules))
 
     @staticmethod
     def include():

--- a/flask_jsglue.py
+++ b/flask_jsglue.py
@@ -107,4 +107,4 @@ var %s = new (function(){
 
     @staticmethod
     def include():
-        return Markup('<script src="%s" type="text/javascript"></script>' % (JSGLUE_JS_PATH, ))
+        return Markup('<script src="%s" type="text/javascript"></script>') % (JSGLUE_JS_PATH, )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ Flask-JSGlue helps hook up your Flask application nicely with the front end.
 
 """
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(
     name='Flask-JSGlue',


### PR DESCRIPTION
Great little plugin, thought I'd try and add a couple improvements:

Use javascript strict mode (throws errors on undefined variables, prevents other bad practices by failing hard, etc)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode

Use `setuptools` if it's available for packaging (lets you install in develop mode, is the preferred packaging tool these days), fall back to distutils if it's not available.

Thanks!
