### PR TITLE
Fix URL generated by JSGlue.include()

### DIFF
--- a/flask_jsglue.py
+++ b/flask_jsglue.py
@@ -1,4 +1,4 @@
-from flask import current_app, make_response
+from flask import current_app, make_response, url_for
 from jinja2 import Markup
 import re, json
 
@@ -107,4 +107,5 @@ var %s = new (function(){
 
     @staticmethod
     def include():
-        return Markup('<script src="%s" type="text/javascript"></script>') % (JSGLUE_JS_PATH, )
+        js_path = url_for('serve_js')
+        return Markup('<script src="%s" type="text/javascript"></script>') % (js_path, )


### PR DESCRIPTION
Currently, the URL generated by `JSGlue.include()` in the script tag is
static and may be incorrect depending on the application configuration.
This change uses `url_for` instead of the static value to handle the case
where the Flask application is not served at the site root. Fixes #2.
