### PR TITLE
Update js_bridge.js

### DIFF
--- a/templates/jsglue/js_bridge.js
+++ b/templates/jsglue/js_bridge.js
@@ -80,7 +80,7 @@ var {{ namespace }} = new(function () {
             if (is_absolute) {
               return scheme + "://" + location.host + url;
             } else {
-              return url;
+              return encodeURI(url);
             }
           }
         }


### PR DESCRIPTION
when we pass parameters containing space it needs to encode url otherwise we get errors