### PR TITLE
Allow deferred loading of script

### DIFF
--- a/flask_jsglue.py
+++ b/flask_jsglue.py
@@ -57,6 +57,9 @@ class JSGlue(object):
             rules=json.dumps(rules))
 
     @staticmethod
-    def include():
+    def include(*, defer=False):
         js_path = url_for('serve_js')
-        return Markup('<script src="%s" type="text/javascript"></script>') % (js_path,)
+        return Markup('<script %s src="%s" type="text/javascript"></script>') % (
+            'defer' if defer else ''
+            js_path,
+        )

--- a/flask_jsglue.py
+++ b/flask_jsglue.py
@@ -61,5 +61,5 @@ class JSGlue(object):
         js_path = url_for('serve_js')
         return Markup('<script %s src="%s" type="text/javascript"></script>') % (
             'defer' if defer else ''
-            js_path,
+            js_path
         )


### PR DESCRIPTION
This PR allows the script loading to be [deferred](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#Attributes) for improved loading performance, default off to preserve compatibility with existing sites. It can be enabled by passing (by keyword only!) `defer=True` to `JSGlue.include()` in a template file.

I do not know how to add a test for this but it is easily manually checked to ensure it works.