### PR TITLE
Fixed Markup import; it is now imported from markupsafe

### DIFF
--- a/flask_jsglue.py
+++ b/flask_jsglue.py
@@ -1,7 +1,9 @@
-from flask import render_template
 from flask import make_response
+from flask import render_template
 from flask import url_for
-from jinja2 import Markup
+
+from markupsafe import Markup
+
 import re
 import json
 


### PR DESCRIPTION
Importing Markup from jinja2 doesn't work anymore. This fixes the issue. Also took the liberty of sorting imports.